### PR TITLE
Apply hw-ops's cookbook template

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,15 +1,17 @@
 .vagrant
-*.lock
+Cheffile.lock
 *~
 *#
 .#*
 \#*#
 .*.sw[a-z]
 *.un~
-.bundle
-.cache
-.kitchen
-.librarian
-bin
-tmp
+tmp/*
+
+# Bundler
+Gemfile.lock
+bin/*
+.bundle/*
+
+.kitchen/
 .kitchen.local.yml

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,16 @@
+AllCops:
+  Exclude:
+    - 'tmp/**/*'
+Style/FileName:
+  Exclude:
+    - 'Guardfile'
+Style/StringLiterals:
+  EnforcedStyle: single_quotes
+Style/PercentLiteralDelimiters:
+  PreferredDelimiters:
+    '%':  '()'
+    '%q': '()'
+    '%Q': '()'
+    '%w': '()'
+    '%W': '()'
+    '%x': '()'

--- a/Gemfile
+++ b/Gemfile
@@ -2,9 +2,17 @@ source 'https://rubygems.org'
 
 gem 'emeril', :group => :release
 
-group :test do
-  gem 'rake'
+group :integration do
   gem 'test-kitchen'
   gem 'kitchen-vagrant'
-  gem 'librarian-chef'
+  gem 'kitchen-docker'
 end
+
+gem 'librarian-chef'
+gem 'foodcritic', '>= 3.0.3'
+gem 'chefspec', '~> 4.0'
+gem 'chef', '~> 11.12'
+gem 'finstyle'
+gem 'guard-rubocop'
+gem 'guard-rspec'
+gem 'guard-foodcritic'

--- a/Guardfile
+++ b/Guardfile
@@ -1,0 +1,31 @@
+#!/usr/bin/env ruby
+# ^syntax detection
+
+require 'finstyle'
+
+guard :rubocop, :keep_failed => false, :cli => '-r finstyle' do
+  watch(%r{.+\.rb$}) { |m| m[0] }
+  watch(%r{(?:.+/)?\.rubocop\.yml$}) { |m| File.dirname(m[0]) }
+end
+
+guard 'foodcritic', :cookbook_paths => '.', :cli => '-C -t ~FC001' do
+  watch(%r{attributes/.+\.rb$})
+  watch(%r{providers/.+\.rb$})
+  watch(%r{recipes/.+\.rb$})
+  watch(%r{resources/.+\.rb$})
+end
+
+spec_path = 'test/unit'
+rspec_guard_config = {
+  :cmd => "bundle exec rspec --color --format progress --default-path=#{spec_path}",
+  :all_on_start => true,
+  :spec_paths => [spec_path]
+}
+
+guard 'rspec', rspec_guard_config do
+  watch(%r{^#{spec_path}/.+_spec\.rb$})
+  watch("#{spec_path}/spec_helper.rb")  { spec_path }
+  watch(%r{^(libraries|providers|recipes|resources)/(.+)\.rb$}) do |m|
+    "#{spec_path}/#{m[2]}_spec.rb"
+  end
+end

--- a/chefignore
+++ b/chefignore
@@ -1,0 +1,95 @@
+# Put files/directories that should be ignored in this file when uploading
+# or sharing to the community site.
+# Lines that start with '# ' are comments.
+
+# OS generated files #
+######################
+.DS_Store
+Icon?
+nohup.out
+ehthumbs.db
+Thumbs.db
+
+# SASS #
+########
+.sass-cache
+
+# EDITORS #
+###########
+\#*
+.#*
+*~
+*.sw[a-z]
+*.bak
+REVISION
+TAGS*
+tmtags
+*_flymake.*
+*_flymake
+*.tmproj
+.project
+.settings
+mkmf.log
+
+## COMPILED ##
+##############
+a.out
+*.o
+*.pyc
+*.so
+*.com
+*.class
+*.dll
+*.exe
+*/rdoc/
+
+# Testing #
+###########
+.watchr
+.rspec
+spec/*
+spec/fixtures/*
+test/*
+features/*
+Guardfile
+Procfile
+
+# SCM #
+#######
+.git
+*/.git
+.gitignore
+.gitmodules
+.gitconfig
+.gitattributes
+.svn
+*/.bzr/*
+*/.hg/*
+*/.svn/*
+
+# Berkshelf #
+#############
+Berksfile
+Berksfile.lock
+cookbooks/*
+tmp
+
+# Cookbooks #
+#############
+CONTRIBUTING
+
+# Strainer #
+############
+Colanderfile
+Strainerfile
+.colander
+.strainer
+
+# Vagrant #
+###########
+.vagrant
+Vagrantfile
+
+# Travis #
+##########
+.travis.yml

--- a/test/integration/default/serverspec/default.rb
+++ b/test/integration/default/serverspec/default.rb
@@ -1,0 +1,3 @@
+require 'serverspec'
+include Serverspec::Helper::Exec
+include Serverspec::Helper::DetectOS

--- a/test/unit/default_spec.rb
+++ b/test/unit/default_spec.rb
@@ -1,0 +1,8 @@
+require 'spec_helper'
+
+describe 'haproxy::default' do
+  let(:chef_run) { ChefSpec::Runner.new.converge(described_recipe) }
+  it 'runs no tests' do
+    expect(chef_run)
+  end
+end

--- a/test/unit/spec_helper.rb
+++ b/test/unit/spec_helper.rb
@@ -1,0 +1,2 @@
+require 'chefspec'
+require 'chefspec/librarian'


### PR DESCRIPTION
Brings the haproxy cookbook up to date with the Heavy Water code generator (https://github.com/hw-cookbooks/chef_code_generator).
