### PR TITLE
Use attribute for "defaults retries" option

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -38,6 +38,7 @@ default['haproxy']['members'] = [{
 default['haproxy']['member_port'] = 8080
 default['haproxy']['member_weight'] = 1
 default['haproxy']['app_server_role'] = "webserver"
+default['haproxy']['defaults_retries'] = 3
 default['haproxy']['balance_algorithm'] = "roundrobin"
 default['haproxy']['enable_ssl'] = false
 default['haproxy']['ssl_incoming_address'] = "0.0.0.0"

--- a/templates/default/haproxy.cfg.erb
+++ b/templates/default/haproxy.cfg.erb
@@ -17,7 +17,7 @@ global
 defaults
   log     global
   mode    <%= node['haproxy']['mode'] %>
-  retries 3
+  retries <%= node['haproxy']['defaults_retries'] %>
 <% @defaults_timeouts.sort.map do | value, time | -%>
   timeout <%= value %> <%= time %>
 <% end -%>


### PR DESCRIPTION
```retries``` was static in haproxy.cfg template.
I just added  simple attribute to allow modifications of this value.