### PR TITLE
Add stat socket level to haproxy.cfg.erb

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -55,6 +55,7 @@ default['haproxy']['enable_stats_socket'] = false
 default['haproxy']['stats_socket_path'] = "/var/run/haproxy.sock"
 default['haproxy']['stats_socket_user'] = node['haproxy']['user']
 default['haproxy']['stats_socket_group'] = node['haproxy']['group']
+default['haproxy']['stats_socket_level'] = 'user'
 default['haproxy']['pid_file'] = "/var/run/haproxy.pid"
 
 default['haproxy']['defaults_options'] = ["httplog", "dontlognull", "redispatch"]

--- a/templates/default/haproxy.cfg.erb
+++ b/templates/default/haproxy.cfg.erb
@@ -8,7 +8,7 @@ global
   user <%= node['haproxy']['user'] %>
   group <%= node['haproxy']['group'] %>
 <% if node['haproxy']['enable_stats_socket'] -%>
-  stats socket <%= node['haproxy']['stats_socket_path'] %> user <%= node['haproxy']['stats_socket_user'] %> group <%= node['haproxy']['stats_socket_group'] %>
+  stats socket <%= node['haproxy']['stats_socket_path'] %> user <%= node['haproxy']['stats_socket_user'] %> group <%= node['haproxy']['stats_socket_group'] %> level <%= node['haproxy']['stats_socket_level'] %>
 <% end -%>
 <% node['haproxy']['global_options'].sort.each do |option, value| %>
   <%= option %> <%= value %>


### PR DESCRIPTION
The stat socket level should be configurable via the haproxy.cfg.erb template, defaulting to 'user'.
