### PR TITLE
Fix errors in configuration file using recipe manual when ssl_enabled

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -24,6 +24,7 @@ default['haproxy']['group'] = "haproxy"
 
 default['haproxy']['enable_default_http'] = true
 default['haproxy']['mode'] = "http"
+default['haproxy']['ssl_mode'] = "http"
 default['haproxy']['incoming_address'] = "0.0.0.0"
 default['haproxy']['incoming_port'] = 80
 default['haproxy']['members'] = [{
@@ -46,6 +47,7 @@ default['haproxy']['enable_ssl'] = false
 default['haproxy']['ssl_incoming_address'] = "0.0.0.0"
 default['haproxy']['ssl_incoming_port'] = 443
 default['haproxy']['ssl_member_port'] = 8443
+default['haproxy']['ssl_crt_path'] = nil
 default['haproxy']['httpchk'] = nil
 default['haproxy']['ssl_httpchk'] = nil
 default['haproxy']['enable_admin'] = true

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -90,6 +90,7 @@ default['haproxy']['source']['use_zlib'] = false
 default['haproxy']['package']['version'] = nil
 
 default['haproxy']['pool_members'] = {}
+default['haproxy']['pool_members_option'] = nil
 default['haproxy']['listeners'] = {
   'listen' => {},
   'frontend' => {},

--- a/recipes/manual.rb
+++ b/recipes/manual.rb
@@ -56,7 +56,7 @@ if conf['enable_default_http']
   pool << "option httpchk #{conf['httpchk']}" if conf['httpchk']
   pool << "cookie #{node['haproxy']['cookie']}" if node['haproxy']['cookie']
   servers = node['haproxy']['members'].map do |member|
-    "#{member['hostname']} #{member['ipaddress']}:#{member['port'] || member_port} weight #{member['weight'] || member_weight} maxconn #{member['max_connections'] || member_max_conn} check"
+    "#{member['hostname']} #{member['ipaddress']}:#{member['port'] || member_port} weight #{member['weight'] || member_weight} maxconn #{member['max_connections'] || member_max_conn} check #{node['haproxy']['pool_members_option']}" 
   end
   haproxy_lb "servers-http" do
     type 'backend'
@@ -88,7 +88,7 @@ if node['haproxy']['enable_ssl']
   pool << "option httpchk #{conf['ssl_httpchk']}" if conf['ssl_httpchk']
   pool << "cookie #{node['haproxy']['cookie']}" if node['haproxy']['cookie']
   servers = node['haproxy']['members'].map do |member|
-    "#{member['hostname']} #{member['ipaddress']}:#{member['ssl_port'] || ssl_member_port} weight #{member['weight'] || member_weight} maxconn #{member['max_connections'] || member_max_conn} check"
+    "#{member['hostname']} #{member['ipaddress']}:#{member['ssl_port'] || ssl_member_port} weight #{member['weight'] || member_weight} maxconn #{member['max_connections'] || member_max_conn} check #{node['haproxy']['pool_members_option']}"
   end
   haproxy_lb "servers-https" do
     type 'backend'


### PR DESCRIPTION
I made few changes in manual.rb to fix following errors when ssl_enabled and option forwardfor enabled with source install.

[ALERT] 175/095301 (13927) : Error(s) found in configuration file : /usr/local/etc/haproxy/haproxy.cfg
[WARNING] 175/095301 (13927) : parsing [/usr/local/etc/haproxy/haproxy.cfg:22] : 'option httplog' not usable with frontend 'https' (needs 'mode http'). Falling back to 'option tcplog'.
[ALERT] 175/095301 (13927) : Proxy 'https': unable to find required default_backend: 'servers-https'.
[WARNING] 175/095301 (13927) : config : 'option forwardfor' ignored for frontend 'https' as it requires HTTP mode.

Also I added ssl certificate path for frontend and cookie set for both backend servers-http and servers-https if specified in attributes. 
