### PR TITLE
remove start from service haproxy

### DIFF
--- a/recipes/install_source.rb
+++ b/recipes/install_source.rb
@@ -99,5 +99,5 @@ end
 
 service "haproxy" do
   supports :restart => true, :status => true, :reload => true
-  action [:enable, :start]
+  action [:enable]
 end


### PR DESCRIPTION
- cant start yet because of missing config, start is triggered after config file is created.
fixes #95