### PR TITLE
Remove haproxy service start since no config exists yet

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email  "cookbooks@opscode.com"
 license           "Apache 2.0"
 description       "Installs and configures haproxy"
 long_description  IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version           "1.6.6"
+version           "1.6.7"
 
 recipe "haproxy", "Installs and configures haproxy"
 recipe "haproxy::app_lb", "Installs and configures haproxy by searching for nodes of a particular role"

--- a/recipes/install_source.rb
+++ b/recipes/install_source.rb
@@ -99,5 +99,5 @@ end
 
 service "haproxy" do
   supports :restart => true, :status => true, :reload => true
-  action [:enable, :start]
+  action [:enable]
 end


### PR DESCRIPTION
I encountered this issue:
https://github.com/hw-cookbooks/haproxy/issues/95

IMO, this can be fixed by not starting the haproxy service with the install recipe and allow the start to be started/restarted by the other recipes/definitions/LWRPs that configure and start the service. Please review when you a get a chance. I am in the process of testing all suites.