### PR TITLE
allow haproxy's syslog len parameter to be set via attribute

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -54,6 +54,7 @@ default['haproxy']['stats_socket_path'] = "/var/run/haproxy.sock"
 default['haproxy']['stats_socket_user'] = node['haproxy']['user']
 default['haproxy']['stats_socket_group'] = node['haproxy']['group']
 default['haproxy']['pid_file'] = "/var/run/haproxy.pid"
+default['haproxy']['syslog']['length'] = nil
 
 default['haproxy']['defaults_options'] = ["httplog", "dontlognull", "redispatch"]
 default['haproxy']['x_forwarded_for'] = false

--- a/templates/default/haproxy.cfg.erb
+++ b/templates/default/haproxy.cfg.erb
@@ -1,6 +1,6 @@
 global
-  log 127.0.0.1   local0
-  log 127.0.0.1   local1 notice
+  log 127.0.0.1  <% unless node['haproxy']['syslog']['length'].nil? %>len <%= node['haproxy']['syslog']['length'] %><% end %> local0
+  log 127.0.0.1  <% unless node['haproxy']['syslog']['length'].nil? %>len <%= node['haproxy']['syslog']['length'] %><% end %> local1 notice
   #log loghost    local0 info
   maxconn <%= node['haproxy']['global_max_connections'] %>
   #debug


### PR DESCRIPTION
add new attribute node['haproxy']['syslog']['length'] to set a max syslog line length in haproxy.cfg.  Default value of nil has no impact and the haproxy default of 1024 will remain. 

See https://cbonte.github.io/haproxy-dconv/configuration-1.5.html#3.1-log

Without this setting, long URLs can result in truncated log entries in the haproxy log file. 