### PR TITLE
Checksum only when remote_file is downloaded

### DIFF
--- a/recipes/install_source.rb
+++ b/recipes/install_source.rb
@@ -48,16 +48,19 @@ download_file_path = ::File.join(Chef::Config[:file_cache_path], "haproxy-#{node
 remote_file download_file_path do
   source node['haproxy']['source']['url']
   checksum node['haproxy']['source']['checksum']
+  notifies :run, 'ruby_block[validate-checksum]'
   action :create_if_missing
 end
 
 ruby_block "Validating checksum for the downloaded tarball" do
+  block_name 'validate-checksum'
   block do
     checksum = Digest::SHA2.file(download_file_path).hexdigest
     if checksum != node['haproxy']['source']['checksum']
       raise "Checksum of the downloaded file #{checksum} does not match known checksum #{node['haproxy']['source']['checksum']}"
     end
   end
+  action :nothing
 end
 
 make_cmd = "make TARGET=#{node['haproxy']['source']['target_os']}"


### PR DESCRIPTION
This PR comes from #125 , now against "develop" branch.

When install from source tarball, the install_source.rb recipe validates the downloaded file every time chef client run.

Chef Client finished, 1/28 resources updated in 04 seconds
This PR makes install_source.rb validate the file only when is downloaded.