### PR TITLE
[COOK-108] - Allow for source build upgrades

### DIFF
--- a/recipes/install_source.rb
+++ b/recipes/install_source.rb
@@ -74,7 +74,7 @@ bash "compile_haproxy" do
     cd haproxy-#{node['haproxy']['source']['version']}
     #{make_cmd} && make install PREFIX=#{node['haproxy']['source']['prefix']}
   EOH
-  creates "#{node['haproxy']['source']['prefix']}/sbin/haproxy"
+  not_if "grep #{node['haproxy']['source']['version']} $(#{node['haproxy']['source']['prefix']}/sbin/haproxy -v)"
 end
 
 user "haproxy" do


### PR DESCRIPTION
I have no idea if this cookbook is really being maintained anymore, but I already had a fix for #108 and thought I would contribute. If master isn't where things should be pulled, this will cherry-pick into develop.

This checks that the version of the installed haproxy binary is different than the configured one, allowing for a newer (or older) version of HAProxy to be installed over an existing one. We've been using this in production for quite a while now with no issues.

Fixes #108
