### PR TITLE
Do a syntax check of the haproxy config

### DIFF
--- a/templates/default/haproxy-init.erb
+++ b/templates/default/haproxy-init.erb
@@ -32,9 +32,19 @@ test "$ENABLED" != "0" || exit 0
 [ -f /etc/default/rcS ] && . /etc/default/rcS
 . /lib/lsb/init-functions
 
+check_haproxy_config()
+{
+  $HAPROXY -c -f "$CONFIG" >/dev/null
+  if [ $? -eq 1 ]; then
+    log_end_msg 1
+    exit 1
+  fi
+}
 
 haproxy_start()
 {
+  check_haproxy_config
+
   start-stop-daemon --start --pidfile "$PIDFILE" \
     --exec $HAPROXY -- -f "$CONFIG" -D -p "$PIDFILE" \
     $EXTRAOPTS || return 2
@@ -56,6 +66,8 @@ haproxy_stop()
 
 haproxy_reload()
 {
+  check_haproxy_config
+
   $HAPROXY -f "$CONFIG" -p $PIDFILE -D $EXTRAOPTS -sf $(cat $PIDFILE) \
     || return 2
   return 0
@@ -126,6 +138,7 @@ reload|force-reload)
   ;;
 restart)
   log_daemon_msg "Restarting haproxy" "haproxy"
+  check_haproxy_config
   haproxy_stop
   haproxy_start
   case "$?" in


### PR DESCRIPTION
If you (accidentally) break the haproxy config, the init script will happily stop haproxy, never to be able to start again without intervention.

This patch checks the haproxy config before reloading or stopping haproxy to prevent this situation.

This brings the init script closer in line with the upstream init scripts of Debian/Ubuntu which does the same check.
